### PR TITLE
Show key path on fail

### DIFF
--- a/lib/ex_unit_assert_match.ex
+++ b/lib/ex_unit_assert_match.ex
@@ -5,8 +5,14 @@ defmodule ExUnitAssertMatch do
 
   alias ExUnitAssertMatch.Types
 
-  def assert(type, data, opts \\ []) do
+  def assert(type, data, opts \\ [])
+
+  def assert(type, data, opts = %ExUnitAssertMatch.Option{}) do
     ExUnitAssertMatch.Type.assert(type, data, opts)
+  end
+
+  def assert(type, data, opts) do
+    assert(type, data, struct(ExUnitAssertMatch.Option, opts))
   end
 
   def map() do

--- a/lib/ex_unit_assert_match/error_message.ex
+++ b/lib/ex_unit_assert_match/error_message.ex
@@ -1,0 +1,24 @@
+defmodule ExUnitAssertMatch.ErrorMessage do
+  def build(base, opts) do
+    base
+    |> append_key_stack(opts.key_stack)
+  end
+
+  defp append_key_stack(message, []) do
+    message
+  end
+
+  defp append_key_stack(message, stack) do
+    path =
+      stack
+      |> Enum.reverse()
+      |> Enum.map(&inspect/1)
+      |> Enum.join(" > ")
+
+    ~s"
+    #{message}
+
+    Key: #{path}
+    "
+  end
+end

--- a/lib/ex_unit_assert_match/error_message.ex
+++ b/lib/ex_unit_assert_match/error_message.ex
@@ -15,10 +15,10 @@ defmodule ExUnitAssertMatch.ErrorMessage do
       |> Enum.map(&inspect/1)
       |> Enum.join(" > ")
 
-    ~s"
+    ~s"""
     #{message}
 
-    Key: #{path}
-    "
+    Path: #{path}
+    """
   end
 end

--- a/lib/ex_unit_assert_match/option.ex
+++ b/lib/ex_unit_assert_match/option.ex
@@ -1,5 +1,6 @@
 defmodule ExUnitAssertMatch.Option do
   defstruct [
-    assertion_module: ExUnit.Assertions
+    assertion_module: ExUnit.Assertions,
+    key_stack: []
   ]
 end

--- a/lib/ex_unit_assert_match/option.ex
+++ b/lib/ex_unit_assert_match/option.ex
@@ -1,0 +1,5 @@
+defmodule ExUnitAssertMatch.Option do
+  defstruct [
+    assertion_module: ExUnit.Assertions
+  ]
+end

--- a/lib/ex_unit_assert_match/option.ex
+++ b/lib/ex_unit_assert_match/option.ex
@@ -1,6 +1,4 @@
 defmodule ExUnitAssertMatch.Option do
-  defstruct [
-    assertion_module: ExUnit.Assertions,
-    key_stack: []
-  ]
+  defstruct assertion_module: ExUnit.Assertions,
+            key_stack: []
 end

--- a/lib/ex_unit_assert_match/types/atom.ex
+++ b/lib/ex_unit_assert_match/types/atom.ex
@@ -2,9 +2,7 @@ defmodule ExUnitAssertMatch.Types.Atom do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    {assertion_module, _opts} = Keyword.pop(opts, :assertion_module, ExUnit.Assertions)
-
-    data |> is_atom() |> assertion_module.assert("Expected #{inspect(data)} is atom")
+    data |> is_atom() |> opts.assertion_module.assert("Expected #{inspect(data)} is atom")
   end
 end
 

--- a/lib/ex_unit_assert_match/types/atom.ex
+++ b/lib/ex_unit_assert_match/types/atom.ex
@@ -2,7 +2,11 @@ defmodule ExUnitAssertMatch.Types.Atom do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    data |> is_atom() |> opts.assertion_module.assert("Expected #{inspect(data)} is atom")
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is atom", opts)
+
+    data
+    |> is_atom()
+    |> opts.assertion_module.assert(message)
   end
 end
 

--- a/lib/ex_unit_assert_match/types/binary.ex
+++ b/lib/ex_unit_assert_match/types/binary.ex
@@ -2,7 +2,11 @@ defmodule ExUnitAssertMatch.Types.Binary do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    data |> is_binary() |> opts.assertion_module.assert("Expected #{inspect(data)} is binary")
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is binary", opts)
+
+    data
+    |> is_binary()
+    |> opts.assertion_module.assert(message)
   end
 end
 

--- a/lib/ex_unit_assert_match/types/binary.ex
+++ b/lib/ex_unit_assert_match/types/binary.ex
@@ -2,9 +2,7 @@ defmodule ExUnitAssertMatch.Types.Binary do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    {assertion_module, _opts} = Keyword.pop(opts, :assertion_module, ExUnit.Assertions)
-
-    data |> is_binary() |> assertion_module.assert("Expected #{inspect(data)} is binary")
+    data |> is_binary() |> opts.assertion_module.assert("Expected #{inspect(data)} is binary")
   end
 end
 

--- a/lib/ex_unit_assert_match/types/float.ex
+++ b/lib/ex_unit_assert_match/types/float.ex
@@ -2,7 +2,11 @@ defmodule ExUnitAssertMatch.Types.Float do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    data |> is_float() |> opts.assertion_module.assert("Expected #{inspect(data)} is float")
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is float", opts)
+
+    data
+    |> is_float()
+    |> opts.assertion_module.assert(message)
   end
 end
 

--- a/lib/ex_unit_assert_match/types/float.ex
+++ b/lib/ex_unit_assert_match/types/float.ex
@@ -2,9 +2,7 @@ defmodule ExUnitAssertMatch.Types.Float do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    {assertion_module, _opts} = Keyword.pop(opts, :assertion_module, ExUnit.Assertions)
-
-    data |> is_float() |> assertion_module.assert("Expected #{inspect(data)} is float")
+    data |> is_float() |> opts.assertion_module.assert("Expected #{inspect(data)} is float")
   end
 end
 

--- a/lib/ex_unit_assert_match/types/integer.ex
+++ b/lib/ex_unit_assert_match/types/integer.ex
@@ -2,9 +2,7 @@ defmodule ExUnitAssertMatch.Types.Integer do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    {assertion_module, _opts} = Keyword.pop(opts, :assertion_module, ExUnit.Assertions)
-
-    data |> is_integer() |> assertion_module.assert("Expected #{inspect(data)} is integer")
+    data |> is_integer() |> opts.assertion_module.assert("Expected #{inspect(data)} is integer")
   end
 end
 

--- a/lib/ex_unit_assert_match/types/integer.ex
+++ b/lib/ex_unit_assert_match/types/integer.ex
@@ -2,7 +2,11 @@ defmodule ExUnitAssertMatch.Types.Integer do
   defstruct []
 
   def assert_self(%__MODULE__{}, data, opts) do
-    data |> is_integer() |> opts.assertion_module.assert("Expected #{inspect(data)} is integer")
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is integer", opts)
+
+    data
+    |> is_integer()
+    |> opts.assertion_module.assert(message)
   end
 end
 

--- a/lib/ex_unit_assert_match/types/list.ex
+++ b/lib/ex_unit_assert_match/types/list.ex
@@ -2,9 +2,7 @@ defmodule ExUnitAssertMatch.Types.List do
   defstruct [:example]
 
   def assert_self(%__MODULE__{}, data, opts) do
-    {assertion_module, _opts} = Keyword.pop(opts, :assertion_module, ExUnit.Assertions)
-
-    data |> is_list() |> assertion_module.assert("Expected #{inspect(data)} is list")
+    data |> is_list() |> opts.assertion_module.assert("Expected #{inspect(data)} is list")
   end
 
   def assert_children(%__MODULE__{example: nil}, _data, _opts) do

--- a/lib/ex_unit_assert_match/types/list.ex
+++ b/lib/ex_unit_assert_match/types/list.ex
@@ -11,6 +11,7 @@ defmodule ExUnitAssertMatch.Types.List do
 
   def assert_children(%__MODULE__{example: nil}, _data, _opts) do
   end
+
   def assert_children(%__MODULE__{example: example}, data, opts) do
     data
     |> Enum.with_index()

--- a/lib/ex_unit_assert_match/types/list.ex
+++ b/lib/ex_unit_assert_match/types/list.ex
@@ -2,13 +2,20 @@ defmodule ExUnitAssertMatch.Types.List do
   defstruct [:example]
 
   def assert_self(%__MODULE__{}, data, opts) do
-    data |> is_list() |> opts.assertion_module.assert("Expected #{inspect(data)} is list")
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is list", opts)
+
+    data
+    |> is_list()
+    |> opts.assertion_module.assert(message)
   end
 
   def assert_children(%__MODULE__{example: nil}, _data, _opts) do
   end
   def assert_children(%__MODULE__{example: example}, data, opts) do
-    Enum.each(data, fn elem ->
+    data
+    |> Enum.with_index()
+    |> Enum.each(fn {elem, index} ->
+      opts = %ExUnitAssertMatch.Option{opts | key_stack: [index | opts.key_stack]}
       ExUnitAssertMatch.assert(example, elem, opts)
     end)
   end

--- a/lib/ex_unit_assert_match/types/literal.ex
+++ b/lib/ex_unit_assert_match/types/literal.ex
@@ -4,7 +4,7 @@ defmodule ExUnitAssertMatch.Types.Literal do
   def assert_self(%__MODULE__{example: literal}, data, opts) do
     message = ExUnitAssertMatch.ErrorMessage.build("Expected #{data} is #{literal}", opts)
 
-    opts.assertion_module.assert literal == data, message
+    opts.assertion_module.assert(literal == data, message)
   end
 end
 

--- a/lib/ex_unit_assert_match/types/literal.ex
+++ b/lib/ex_unit_assert_match/types/literal.ex
@@ -2,9 +2,7 @@ defmodule ExUnitAssertMatch.Types.Literal do
   defstruct [:example]
 
   def assert_self(%__MODULE__{example: literal}, data, opts) do
-    {assertion_module, _opts} = Keyword.pop(opts, :assertion_module, ExUnit.Assertions)
-
-    assertion_module.assert literal == data, "Expected #{data} is #{literal}"
+    opts.assertion_module.assert literal == data, "Expected #{data} is #{literal}"
   end
 end
 

--- a/lib/ex_unit_assert_match/types/literal.ex
+++ b/lib/ex_unit_assert_match/types/literal.ex
@@ -2,7 +2,9 @@ defmodule ExUnitAssertMatch.Types.Literal do
   defstruct [:example]
 
   def assert_self(%__MODULE__{example: literal}, data, opts) do
-    opts.assertion_module.assert literal == data, "Expected #{data} is #{literal}"
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{data} is #{literal}", opts)
+
+    opts.assertion_module.assert literal == data, message
   end
 end
 

--- a/lib/ex_unit_assert_match/types/map.ex
+++ b/lib/ex_unit_assert_match/types/map.ex
@@ -2,13 +2,18 @@ defmodule ExUnitAssertMatch.Types.Map do
   defstruct [:example]
 
   def assert_self(%__MODULE__{}, data, opts) do
-    data |> is_map() |> opts.assertion_module.assert("Expected #{inspect(data)} is map")
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is map", opts)
+
+    data
+    |> is_map()
+    |> opts.assertion_module.assert(message)
   end
 
   def assert_children(%__MODULE__{example: nil}, _data, _opts) do
   end
   def assert_children(%__MODULE__{example: example}, data, opts) do
     Enum.each(example, fn {key, val} ->
+      opts = %ExUnitAssertMatch.Option{opts | key_stack: [key | opts.key_stack]}
       ExUnitAssertMatch.assert(val, Map.get(data, key), opts)
     end)
   end

--- a/lib/ex_unit_assert_match/types/map.ex
+++ b/lib/ex_unit_assert_match/types/map.ex
@@ -2,9 +2,7 @@ defmodule ExUnitAssertMatch.Types.Map do
   defstruct [:example]
 
   def assert_self(%__MODULE__{}, data, opts) do
-    {assertion_module, _opts} = Keyword.pop(opts, :assertion_module, ExUnit.Assertions)
-
-    data |> is_map() |> assertion_module.assert("Expected #{inspect(data)} is map")
+    data |> is_map() |> opts.assertion_module.assert("Expected #{inspect(data)} is map")
   end
 
   def assert_children(%__MODULE__{example: nil}, _data, _opts) do

--- a/lib/ex_unit_assert_match/types/map.ex
+++ b/lib/ex_unit_assert_match/types/map.ex
@@ -11,6 +11,7 @@ defmodule ExUnitAssertMatch.Types.Map do
 
   def assert_children(%__MODULE__{example: nil}, _data, _opts) do
   end
+
   def assert_children(%__MODULE__{example: example}, data, opts) do
     Enum.each(example, fn {key, val} ->
       opts = %ExUnitAssertMatch.Option{opts | key_stack: [key | opts.key_stack]}

--- a/test/error_message_test.exs
+++ b/test/error_message_test.exs
@@ -1,0 +1,28 @@
+defmodule ExUnitAssertMatch.ErrorMessageTest do
+  use ExUnit.Case, async: true
+
+  alias ExUnitAssertMatch.{ErrorMessage, Option}
+
+  describe "build without stack" do
+    setup do
+      %{opts: %Option{key_stack: []}}
+    end
+
+    test "return given message as is", %{opts: opts} do
+      assert ErrorMessage.build("something went wrong", opts) == "something went wrong"
+    end
+  end
+
+  describe "build with stack" do
+    setup do
+      %{opts: %Option{key_stack: ["name", 1, :orgs]}}
+    end
+
+    test "append keys", %{opts: opts} do
+      message = ErrorMessage.build("something went wrong", opts)
+
+      assert message =~ "something went wrong"
+      assert message =~ ":orgs > 1 > \"name\""
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,10 +1,10 @@
 defmodule ExUnitAssertMatch.ThrowTupleOnFail do
   def assert(bool, message \\ "")
   def assert(true, message), do: {:ok, message}
-  def assert(false, message), do: throw {:error, message}
+  def assert(false, message), do: throw({:error, message})
 
   def refute(bool, message \\ "")
-  def refute(true, message), do: throw {:error, message}
+  def refute(true, message), do: throw({:error, message})
   def refute(false, message), do: {:ok, message}
 end
 

--- a/test/types/any_test.exs
+++ b/test/types/any_test.exs
@@ -1,20 +1,20 @@
 defmodule ExUnitAssertMatch.Types.AnyTest do
   use ExUnit.Case, async: false
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   setup do
-    %{type: %Types.Any{}}
+    %{type: %Types.Any{}, opts: %Option{}}
   end
 
   describe "assert" do
-    test "always pass", %{type: type} do
-      Type.assert(type, "abc")
-      Type.assert(type, 123)
-      Type.assert(type, 3.14)
-      Type.assert(type, %{})
-      Type.assert(type, [1, 2, 3])
-      Type.assert(type, :atom)
+    test "always pass", %{type: type, opts: opts} do
+      Type.assert(type, "abc", opts)
+      Type.assert(type, 123, opts)
+      Type.assert(type, 3.14, opts)
+      Type.assert(type, %{}, opts)
+      Type.assert(type, [1, 2, 3], opts)
+      Type.assert(type, :atom, opts)
     end
   end
 end

--- a/test/types/atom_test.exs
+++ b/test/types/atom_test.exs
@@ -10,7 +10,7 @@ defmodule ExUnitAssertMatch.Types.AtomTest do
   describe "assert" do
     test "pass if atom is given", %{type: type, opts: opts} do
       Type.assert(type, :atom, opts)
-      Type.assert(type, :'hello world', opts)
+      Type.assert(type, :"hello world", opts)
       Type.assert(type, Elixir, opts)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}

--- a/test/types/atom_test.exs
+++ b/test/types/atom_test.exs
@@ -1,19 +1,19 @@
 defmodule ExUnitAssertMatch.Types.AtomTest do
   use ExUnit.Case, async: false
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   setup do
-    %{type: %Types.Atom{}}
+    %{type: %Types.Atom{}, opts: %Option{}}
   end
 
   describe "assert" do
-    test "pass if atom is given", %{type: type} do
-      Type.assert(type, :atom)
-      Type.assert(type, :'hello world')
-      Type.assert(type, Elixir)
+    test "pass if atom is given", %{type: type, opts: opts} do
+      Type.assert(type, :atom, opts)
+      Type.assert(type, :'hello world', opts)
+      Type.assert(type, Elixir, opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, 'abc', opts))
       assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts))
       assert {:error, _} = catch_throw(Type.assert(type, [:a], opts))

--- a/test/types/binary_test.exs
+++ b/test/types/binary_test.exs
@@ -1,19 +1,19 @@
 defmodule ExUnitAssertMatch.Types.BinaryTest do
   use ExUnit.Case, async: false
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   setup do
-    %{type: %Types.Binary{}}
+    %{type: %Types.Binary{}, opts: %Option{}}
   end
 
   describe "assert" do
-    test "return true if it's binary", %{type: type} do
-      Type.assert(type, "abc")
-      Type.assert(type, "")
-      Type.assert(type, <<123, 456>>)
+    test "return true if it's binary", %{type: type, opts: opts} do
+      Type.assert(type, "abc", opts)
+      Type.assert(type, "", opts)
+      Type.assert(type, <<123, 456>>, opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, 1, opts))
       assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts))
       assert {:error, _} = catch_throw(Type.assert(type, [:a], opts))

--- a/test/types/float_test.exs
+++ b/test/types/float_test.exs
@@ -1,18 +1,18 @@
 defmodule ExUnitAssertMatch.Types.FloatTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   setup do
-    %{type: %Types.Float{}}
+    %{type: %Types.Float{}, opts: %Option{}}
   end
 
   describe "assert" do
-    test "return true if it's float", %{type: type} do
-      Type.assert(type, 0.0)
-      Type.assert(type, 3.14)
+    test "return true if it's float", %{type: type, opts: opts} do
+      Type.assert(type, 0.0, opts)
+      Type.assert(type, 3.14, opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, 1, opts))
       assert {:error, _} = catch_throw(Type.assert(type, "1.0", opts))
       assert {:error, _} = catch_throw(Type.assert(type, [:a], opts))

--- a/test/types/integer_test.exs
+++ b/test/types/integer_test.exs
@@ -1,19 +1,19 @@
 defmodule ExUnitAssertMatch.Types.IntegerTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   setup do
-    %{type: %Types.Integer{}}
+    %{type: %Types.Integer{}, opts: %Option{}}
   end
 
   describe "assert" do
-    test "return true if it's integer", %{type: type} do
-      Type.assert(type, 1)
-      Type.assert(type, 0)
-      Type.assert(type, -1)
+    test "return true if it's integer", %{type: type, opts: opts} do
+      Type.assert(type, 1, opts)
+      Type.assert(type, 0, opts)
+      Type.assert(type, -1, opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, "1", opts))
       assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts))
     end

--- a/test/types/list_test.exs
+++ b/test/types/list_test.exs
@@ -1,18 +1,18 @@
 defmodule ExUnitAssertMatch.Types.ListTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   describe "without example" do
     setup do
-      %{type: %Types.List{}}
+      %{type: %Types.List{}, opts: %Option{}}
     end
 
-    test "return true if it's list", %{type: type} do
-      Type.assert(type, [])
-      Type.assert(type, [1, 2, 3])
+    test "return true if it's list", %{type: type, opts: opts} do
+      Type.assert(type, [], opts)
+      Type.assert(type, [1, 2, 3], opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, "1", opts))
       assert {:error, _} = catch_throw(Type.assert(type, :list, opts))
     end
@@ -22,14 +22,14 @@ defmodule ExUnitAssertMatch.Types.ListTest do
     setup do
       type = %Types.List{example: %Types.Binary{}}
 
-      %{type: type}
+      %{type: type, opts: %Option{}}
     end
 
-    test "fails if the element does not match", %{type: type} do
-      Type.assert(type, [])
-      Type.assert(type, ["a", "b", "c"])
+    test "fails if the element does not match", %{type: type, opts: opts} do
+      Type.assert(type, [], opts)
+      Type.assert(type, ["a", "b", "c"], opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, [1, 2, 3], opts))
     end
   end

--- a/test/types/literal_test.exs
+++ b/test/types/literal_test.exs
@@ -1,17 +1,17 @@
 defmodule ExUnitAssertMatch.Types.LiteralTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   setup do
-    %{type: %Types.Literal{example: "hello"}}
+    %{type: %Types.Literal{example: "hello"}, opts: %Option{}}
   end
 
   describe "assert" do
-    test "pass if match with `==`", %{type: type} do
-      Type.assert(type, "hello")
+    test "pass if match with `==`", %{type: type, opts: opts} do
+      Type.assert(type, "hello", opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, :hello, opts))
       assert {:error, _} = catch_throw(Type.assert(type, "Hello", opts))
     end

--- a/test/types/map_test.exs
+++ b/test/types/map_test.exs
@@ -20,9 +20,11 @@ defmodule ExUnitAssertMatch.Types.MapTest do
 
   describe "with example" do
     setup do
-      type = %Types.Map{example: %{
-        name: %Types.Binary{}
-      }}
+      type = %Types.Map{
+        example: %{
+          name: %Types.Binary{}
+        }
+      }
 
       %{type: type, opts: %Option{}}
     end

--- a/test/types/map_test.exs
+++ b/test/types/map_test.exs
@@ -1,18 +1,18 @@
 defmodule ExUnitAssertMatch.Types.MapTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types}
+  alias ExUnitAssertMatch.{Type, Types, Option}
 
   describe "without example" do
     setup do
-      %{type: %Types.Map{}}
+      %{type: %Types.Map{}, opts: %Option{}}
     end
 
-    test "return true if it's map", %{type: type} do
-      Type.assert(type, %{})
-      Type.assert(type, %{a: 1})
+    test "return true if it's map", %{type: type, opts: opts} do
+      Type.assert(type, %{}, opts)
+      Type.assert(type, %{a: 1}, opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, "1", opts))
       assert {:error, _} = catch_throw(Type.assert(type, :map, opts))
     end
@@ -24,13 +24,13 @@ defmodule ExUnitAssertMatch.Types.MapTest do
         name: %Types.Binary{}
       }}
 
-      %{type: type}
+      %{type: type, opts: %Option{}}
     end
 
-    test "fails if the element does not match", %{type: type} do
-      Type.assert(type, %{name: "John"})
+    test "fails if the element does not match", %{type: type, opts: opts} do
+      Type.assert(type, %{name: "John"}, opts)
 
-      opts = [assertion_module: ExUnitAssertMatch.ThrowTupleOnFail]
+      opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
       assert {:error, _} = catch_throw(Type.assert(type, %{}, opts))
       assert {:error, _} = catch_throw(Type.assert(type, %{name: :john}, opts))
       assert {:error, _} = catch_throw(Type.assert(type, %{age: 28}, opts))


### PR DESCRIPTION
To clarify which part does not match.

```
Expected "github" is atom

Path: :orgs > 0 > :id
```