### PR TITLE
Nullable helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0 WIP
 
 - Support nullable
+- Add `nullable_xxx` helpers
 
 ## 0.1.0
 

--- a/lib/ex_unit_assert_match.ex
+++ b/lib/ex_unit_assert_match.ex
@@ -57,10 +57,6 @@ defmodule ExUnitAssertMatch do
     %Types.Nullable{example: example}
   end
 
-  def nillable(example) do
-    nullable(example)
-  end
-
   def any() do
     %Types.Any{}
   end

--- a/lib/ex_unit_assert_match.ex
+++ b/lib/ex_unit_assert_match.ex
@@ -64,4 +64,26 @@ defmodule ExUnitAssertMatch do
   def any() do
     %Types.Any{}
   end
+
+  Enum.each(~w[map list atom binary integer float]a, fn type ->
+    name = String.to_atom("nullable_" <> to_string(type))
+
+    @doc """
+    Helper function to call `nullable(#{type}())`.
+    """
+    def unquote(name)() do
+      nullable(unquote(type)())
+    end
+  end)
+
+  Enum.each(~w[map list_of literal]a, fn type ->
+    name = String.to_atom("nullable_" <> to_string(type))
+
+    @doc """
+    Helper function to call `nullable(#{type}(example))`.
+    """
+    def unquote(name)(example) do
+      nullable(unquote(type)(example))
+    end
+  end)
 end

--- a/test/ex_unit_assert_match_test.exs
+++ b/test/ex_unit_assert_match_test.exs
@@ -36,6 +36,15 @@ defmodule ExUnitAssertMatchTest do
     })
   end
 
-  describe "aliases" do
+  test "aliases" do
+    assert M.nullable_atom() == M.nullable(M.atom())
+    assert M.nullable_binary() == M.nullable(M.binary())
+    assert M.nullable_integer() == M.nullable(M.integer())
+    assert M.nullable_float() == M.nullable(M.float())
+    assert M.nullable_map() == M.nullable(M.map())
+    assert M.nullable_list() == M.nullable(M.list())
+    assert M.nullable_map(M.atom()) == M.nullable(M.map(M.atom()))
+    assert M.nullable_list_of(M.atom()) == M.nullable(M.list_of(M.atom()))
+    assert M.nullable_literal("Hello") == M.nullable(M.literal("Hello"))
   end
 end

--- a/test/ex_unit_assert_match_test.exs
+++ b/test/ex_unit_assert_match_test.exs
@@ -37,8 +37,5 @@ defmodule ExUnitAssertMatchTest do
   end
 
   describe "aliases" do
-    test "nullable is nillable" do
-      assert M.nullable(M.integer()) == M.nillable(M.integer())
-    end
   end
 end


### PR DESCRIPTION
- Add helpers to call nullable attributes.
  - You can call `nullable_binary()` instead of `nullable(binary())`.
- Remove `nillable` alias.
  - Because it's too messy that there are helpers `nullable_xx` and `nillable_xxx`.