### PR TITLE
Add equal alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Support nullable
 - Add `nullable_xxx` helpers
+- Add `equal` which is alias of `literal`
 
 ## 0.1.0
 

--- a/lib/ex_unit_assert_match.ex
+++ b/lib/ex_unit_assert_match.ex
@@ -53,6 +53,10 @@ defmodule ExUnitAssertMatch do
     %Types.Literal{example: example}
   end
 
+  def equal(example) do
+    literal(example)
+  end
+
   def nullable(example) do
     %Types.Nullable{example: example}
   end

--- a/test/ex_unit_assert_match_test.exs
+++ b/test/ex_unit_assert_match_test.exs
@@ -37,6 +37,7 @@ defmodule ExUnitAssertMatchTest do
   end
 
   test "aliases" do
+    assert M.literal("Hello") == M.equal("Hello")
     assert M.nullable_atom() == M.nullable(M.atom())
     assert M.nullable_binary() == M.nullable(M.binary())
     assert M.nullable_integer() == M.nullable(M.integer())


### PR DESCRIPTION
Passing a variable to function `literal` is little bit unnatural.

```elixir
M.map(%{name: M.literal(foo)})
```

can be called

```elixir
M.map(%{name: M.equal(foo)})
```