### PR TITLE
Separate options and state

### DIFF
--- a/lib/ex_unit_assert_match.ex
+++ b/lib/ex_unit_assert_match.ex
@@ -5,7 +5,7 @@ defmodule ExUnitAssertMatch do
   The usage is on [README](./readme.html#usage).
   """
 
-  alias ExUnitAssertMatch.{Types, Option, InternalState}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   @doc """
   Assert that given `data` match `type` specification.
@@ -23,7 +23,7 @@ defmodule ExUnitAssertMatch do
   def assert(type, data, opts \\ [])
 
   def assert(type, data, opts = %Option{}) do
-    ExUnitAssertMatch.Type.assert(type, data, opts, %InternalState{})
+    Type.assert(type, data, opts, %InternalState{})
   end
 
   def assert(type, data, opts) do
@@ -31,7 +31,7 @@ defmodule ExUnitAssertMatch do
   end
 
   def assert(type, data, opts, state) do
-    ExUnitAssertMatch.Type.assert(type, data, opts, state)
+    Type.assert(type, data, opts, state)
   end
 
   @doc """

--- a/lib/ex_unit_assert_match.ex
+++ b/lib/ex_unit_assert_match.ex
@@ -5,7 +5,7 @@ defmodule ExUnitAssertMatch do
   The usage is on [README](./readme.html#usage).
   """
 
-  alias ExUnitAssertMatch.Types
+  alias ExUnitAssertMatch.{Types, Option, InternalState}
 
   @doc """
   Assert that given `data` match `type` specification.
@@ -22,12 +22,16 @@ defmodule ExUnitAssertMatch do
   """
   def assert(type, data, opts \\ [])
 
-  def assert(type, data, opts = %ExUnitAssertMatch.Option{}) do
-    ExUnitAssertMatch.Type.assert(type, data, opts)
+  def assert(type, data, opts = %Option{}) do
+    ExUnitAssertMatch.Type.assert(type, data, opts, %InternalState{})
   end
 
   def assert(type, data, opts) do
-    assert(type, data, struct(ExUnitAssertMatch.Option, opts))
+    assert(type, data, struct(Option, opts), %InternalState{})
+  end
+
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Type.assert(type, data, opts, state)
   end
 
   @doc """

--- a/lib/ex_unit_assert_match/error_message.ex
+++ b/lib/ex_unit_assert_match/error_message.ex
@@ -1,9 +1,9 @@
 defmodule ExUnitAssertMatch.ErrorMessage do
   @moduledoc false
 
-  def build(base, opts) do
+  def build(base, state) do
     base
-    |> append_key_stack(opts.key_stack)
+    |> append_key_stack(state.key_stack)
   end
 
   defp append_key_stack(message, []) do

--- a/lib/ex_unit_assert_match/internal_state.ex
+++ b/lib/ex_unit_assert_match/internal_state.ex
@@ -1,0 +1,5 @@
+defmodule ExUnitAssertMatch.InternalState do
+  @moduledoc false
+
+  defstruct key_stack: []
+end

--- a/lib/ex_unit_assert_match/option.ex
+++ b/lib/ex_unit_assert_match/option.ex
@@ -1,6 +1,5 @@
 defmodule ExUnitAssertMatch.Option do
   @moduledoc false
 
-  defstruct assertion_module: ExUnit.Assertions,
-            key_stack: []
+  defstruct assertion_module: ExUnit.Assertions
 end

--- a/lib/ex_unit_assert_match/type.ex
+++ b/lib/ex_unit_assert_match/type.ex
@@ -4,5 +4,5 @@ defprotocol ExUnitAssertMatch.Type do
   @doc """
   Asserts given `data` match `type`.
   """
-  def assert(type, data, opts \\ [])
+  def assert(type, data, opts, state)
 end

--- a/lib/ex_unit_assert_match/types/any.ex
+++ b/lib/ex_unit_assert_match/types/any.ex
@@ -5,7 +5,7 @@ defmodule ExUnitAssertMatch.Types.Any do
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Any do
-  def assert(_type, _data, _opts \\ []) do
-    # do nothing
+  def assert(_type, _data, _opts, _state) do
+    # Do nothing. Always pass.
   end
 end

--- a/lib/ex_unit_assert_match/types/atom.ex
+++ b/lib/ex_unit_assert_match/types/atom.ex
@@ -3,8 +3,8 @@ defmodule ExUnitAssertMatch.Types.Atom do
 
   defstruct []
 
-  def assert_self(%__MODULE__{}, data, opts) do
-    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is atom", opts)
+  def assert_self(%__MODULE__{}, data, opts, state) do
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is atom", state)
 
     data
     |> is_atom()
@@ -13,7 +13,7 @@ defmodule ExUnitAssertMatch.Types.Atom do
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Atom do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.Atom.assert_self(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.Atom.assert_self(type, data, opts, state)
   end
 end

--- a/lib/ex_unit_assert_match/types/binary.ex
+++ b/lib/ex_unit_assert_match/types/binary.ex
@@ -3,8 +3,8 @@ defmodule ExUnitAssertMatch.Types.Binary do
 
   defstruct []
 
-  def assert_self(%__MODULE__{}, data, opts) do
-    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is binary", opts)
+  def assert_self(%__MODULE__{}, data, opts, state) do
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is binary", state)
 
     data
     |> is_binary()
@@ -13,7 +13,7 @@ defmodule ExUnitAssertMatch.Types.Binary do
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Binary do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.Binary.assert_self(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.Binary.assert_self(type, data, opts, state)
   end
 end

--- a/lib/ex_unit_assert_match/types/float.ex
+++ b/lib/ex_unit_assert_match/types/float.ex
@@ -3,8 +3,8 @@ defmodule ExUnitAssertMatch.Types.Float do
 
   defstruct []
 
-  def assert_self(%__MODULE__{}, data, opts) do
-    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is float", opts)
+  def assert_self(%__MODULE__{}, data, opts, state) do
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is float", state)
 
     data
     |> is_float()
@@ -13,7 +13,7 @@ defmodule ExUnitAssertMatch.Types.Float do
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Float do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.Float.assert_self(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.Float.assert_self(type, data, opts, state)
   end
 end

--- a/lib/ex_unit_assert_match/types/integer.ex
+++ b/lib/ex_unit_assert_match/types/integer.ex
@@ -3,8 +3,8 @@ defmodule ExUnitAssertMatch.Types.Integer do
 
   defstruct []
 
-  def assert_self(%__MODULE__{}, data, opts) do
-    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is integer", opts)
+  def assert_self(%__MODULE__{}, data, opts, state) do
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is integer", state)
 
     data
     |> is_integer()
@@ -13,7 +13,7 @@ defmodule ExUnitAssertMatch.Types.Integer do
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Integer do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.Integer.assert_self(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.Integer.assert_self(type, data, opts, state)
   end
 end

--- a/lib/ex_unit_assert_match/types/list.ex
+++ b/lib/ex_unit_assert_match/types/list.ex
@@ -3,30 +3,30 @@ defmodule ExUnitAssertMatch.Types.List do
 
   defstruct [:example]
 
-  def assert_self(%__MODULE__{}, data, opts) do
-    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is list", opts)
+  def assert_self(%__MODULE__{}, data, opts, state) do
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is list", state)
 
     data
     |> is_list()
     |> opts.assertion_module.assert(message)
   end
 
-  def assert_children(%__MODULE__{example: nil}, _data, _opts) do
+  def assert_children(%__MODULE__{example: nil}, _data, _opts, _state) do
   end
 
-  def assert_children(%__MODULE__{example: example}, data, opts) do
+  def assert_children(%__MODULE__{example: example}, data, opts, state) do
     data
     |> Enum.with_index()
     |> Enum.each(fn {elem, index} ->
-      opts = %ExUnitAssertMatch.Option{opts | key_stack: [index | opts.key_stack]}
-      ExUnitAssertMatch.assert(example, elem, opts)
+      state = %ExUnitAssertMatch.InternalState{state | key_stack: [index | state.key_stack]}
+      ExUnitAssertMatch.assert(example, elem, opts, state)
     end)
   end
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.List do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.List.assert_self(type, data, opts)
-    ExUnitAssertMatch.Types.List.assert_children(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.List.assert_self(type, data, opts, state)
+    ExUnitAssertMatch.Types.List.assert_children(type, data, opts, state)
   end
 end

--- a/lib/ex_unit_assert_match/types/literal.ex
+++ b/lib/ex_unit_assert_match/types/literal.ex
@@ -3,15 +3,15 @@ defmodule ExUnitAssertMatch.Types.Literal do
 
   defstruct [:example]
 
-  def assert_self(%__MODULE__{example: literal}, data, opts) do
-    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{data} is #{literal}", opts)
+  def assert_self(%__MODULE__{example: literal}, data, opts, state) do
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{data} is #{literal}", state)
 
     opts.assertion_module.assert(literal == data, message)
   end
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Literal do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.Literal.assert_self(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.Literal.assert_self(type, data, opts, state)
   end
 end

--- a/lib/ex_unit_assert_match/types/map.ex
+++ b/lib/ex_unit_assert_match/types/map.ex
@@ -3,28 +3,28 @@ defmodule ExUnitAssertMatch.Types.Map do
 
   defstruct [:example]
 
-  def assert_self(%__MODULE__{}, data, opts) do
-    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is map", opts)
+  def assert_self(%__MODULE__{}, data, opts, state) do
+    message = ExUnitAssertMatch.ErrorMessage.build("Expected #{inspect(data)} is map", state)
 
     data
     |> is_map()
     |> opts.assertion_module.assert(message)
   end
 
-  def assert_children(%__MODULE__{example: nil}, _data, _opts) do
+  def assert_children(%__MODULE__{example: nil}, _data, _opts, _state) do
   end
 
-  def assert_children(%__MODULE__{example: example}, data, opts) do
+  def assert_children(%__MODULE__{example: example}, data, opts, state) do
     Enum.each(example, fn {key, val} ->
-      opts = %ExUnitAssertMatch.Option{opts | key_stack: [key | opts.key_stack]}
-      ExUnitAssertMatch.assert(val, Map.get(data, key), opts)
+      state = %ExUnitAssertMatch.InternalState{state | key_stack: [key | state.key_stack]}
+      ExUnitAssertMatch.assert(val, Map.get(data, key), opts, state)
     end)
   end
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Map do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.Map.assert_self(type, data, opts)
-    ExUnitAssertMatch.Types.Map.assert_children(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.Map.assert_self(type, data, opts, state)
+    ExUnitAssertMatch.Types.Map.assert_children(type, data, opts, state)
   end
 end

--- a/lib/ex_unit_assert_match/types/nullable.ex
+++ b/lib/ex_unit_assert_match/types/nullable.ex
@@ -3,16 +3,16 @@ defmodule ExUnitAssertMatch.Types.Nullable do
 
   defstruct [:example]
 
-  def assert_self(%__MODULE__{}, nil, _opts) do
+  def assert_self(%__MODULE__{}, nil, _opts, _state) do
   end
 
-  def assert_self(%__MODULE__{example: example}, data, opts) do
-    ExUnitAssertMatch.assert(example, data, opts)
+  def assert_self(%__MODULE__{example: example}, data, opts, state) do
+    ExUnitAssertMatch.assert(example, data, opts, state)
   end
 end
 
 defimpl ExUnitAssertMatch.Type, for: ExUnitAssertMatch.Types.Nullable do
-  def assert(type, data, opts \\ []) do
-    ExUnitAssertMatch.Types.Nullable.assert_self(type, data, opts)
+  def assert(type, data, opts, state) do
+    ExUnitAssertMatch.Types.Nullable.assert_self(type, data, opts, state)
   end
 end

--- a/test/error_message_test.exs
+++ b/test/error_message_test.exs
@@ -1,25 +1,25 @@
 defmodule ExUnitAssertMatch.ErrorMessageTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{ErrorMessage, Option}
+  alias ExUnitAssertMatch.{ErrorMessage, InternalState}
 
   describe "build without stack" do
     setup do
-      %{opts: %Option{key_stack: []}}
+      %{state: %InternalState{key_stack: []}}
     end
 
-    test "return given message as is", %{opts: opts} do
-      assert ErrorMessage.build("something went wrong", opts) == "something went wrong"
+    test "return given message as is", %{state: state} do
+      assert ErrorMessage.build("something went wrong", state) == "something went wrong"
     end
   end
 
   describe "build with stack" do
     setup do
-      %{opts: %Option{key_stack: ["name", 1, :orgs]}}
+      %{state: %InternalState{key_stack: ["name", 1, :orgs]}}
     end
 
-    test "append keys", %{opts: opts} do
-      message = ErrorMessage.build("something went wrong", opts)
+    test "append keys", %{state: state} do
+      message = ErrorMessage.build("something went wrong", state)
 
       assert message =~ "something went wrong"
       assert message =~ ":orgs > 1 > \"name\""

--- a/test/types/any_test.exs
+++ b/test/types/any_test.exs
@@ -1,20 +1,20 @@
 defmodule ExUnitAssertMatch.Types.AnyTest do
   use ExUnit.Case, async: false
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   setup do
-    %{type: %Types.Any{}, opts: %Option{}}
+    %{type: %Types.Any{}, opts: %Option{}, state: %InternalState{}}
   end
 
   describe "assert" do
-    test "always pass", %{type: type, opts: opts} do
-      Type.assert(type, "abc", opts)
-      Type.assert(type, 123, opts)
-      Type.assert(type, 3.14, opts)
-      Type.assert(type, %{}, opts)
-      Type.assert(type, [1, 2, 3], opts)
-      Type.assert(type, :atom, opts)
+    test "always pass", %{type: type, opts: opts, state: state} do
+      Type.assert(type, "abc", opts, state)
+      Type.assert(type, 123, opts, state)
+      Type.assert(type, 3.14, opts, state)
+      Type.assert(type, %{}, opts, state)
+      Type.assert(type, [1, 2, 3], opts, state)
+      Type.assert(type, :atom, opts, state)
     end
   end
 end

--- a/test/types/atom_test.exs
+++ b/test/types/atom_test.exs
@@ -1,22 +1,22 @@
 defmodule ExUnitAssertMatch.Types.AtomTest do
   use ExUnit.Case, async: false
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   setup do
-    %{type: %Types.Atom{}, opts: %Option{}}
+    %{type: %Types.Atom{}, opts: %Option{}, state: %InternalState{}}
   end
 
   describe "assert" do
-    test "pass if atom is given", %{type: type, opts: opts} do
-      Type.assert(type, :atom, opts)
-      Type.assert(type, :"hello world", opts)
-      Type.assert(type, Elixir, opts)
+    test "pass if atom is given", %{type: type, opts: opts, state: state} do
+      Type.assert(type, :atom, opts, state)
+      Type.assert(type, :"hello world", opts, state)
+      Type.assert(type, Elixir, opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, 'abc', opts))
-      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, [:a], opts))
+      assert {:error, _} = catch_throw(Type.assert(type, 'abc', opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, [:a], opts, state))
     end
   end
 end

--- a/test/types/binary_test.exs
+++ b/test/types/binary_test.exs
@@ -1,22 +1,22 @@
 defmodule ExUnitAssertMatch.Types.BinaryTest do
   use ExUnit.Case, async: false
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   setup do
-    %{type: %Types.Binary{}, opts: %Option{}}
+    %{type: %Types.Binary{}, opts: %Option{}, state: %InternalState{}}
   end
 
   describe "assert" do
-    test "return true if it's binary", %{type: type, opts: opts} do
-      Type.assert(type, "abc", opts)
-      Type.assert(type, "", opts)
-      Type.assert(type, <<123, 456>>, opts)
+    test "return true if it's binary", %{type: type, opts: opts, state: state} do
+      Type.assert(type, "abc", opts, state)
+      Type.assert(type, "", opts, state)
+      Type.assert(type, <<123, 456>>, opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, 1, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, [:a], opts))
+      assert {:error, _} = catch_throw(Type.assert(type, 1, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, [:a], opts, state))
     end
   end
 end

--- a/test/types/float_test.exs
+++ b/test/types/float_test.exs
@@ -1,21 +1,21 @@
 defmodule ExUnitAssertMatch.Types.FloatTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   setup do
-    %{type: %Types.Float{}, opts: %Option{}}
+    %{type: %Types.Float{}, opts: %Option{}, state: %InternalState{}}
   end
 
   describe "assert" do
-    test "return true if it's float", %{type: type, opts: opts} do
-      Type.assert(type, 0.0, opts)
-      Type.assert(type, 3.14, opts)
+    test "return true if it's float", %{type: type, opts: opts, state: state} do
+      Type.assert(type, 0.0, opts, state)
+      Type.assert(type, 3.14, opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, 1, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, "1.0", opts))
-      assert {:error, _} = catch_throw(Type.assert(type, [:a], opts))
+      assert {:error, _} = catch_throw(Type.assert(type, 1, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, "1.0", opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, [:a], opts, state))
     end
   end
 end

--- a/test/types/integer_test.exs
+++ b/test/types/integer_test.exs
@@ -1,21 +1,21 @@
 defmodule ExUnitAssertMatch.Types.IntegerTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   setup do
-    %{type: %Types.Integer{}, opts: %Option{}}
+    %{type: %Types.Integer{}, opts: %Option{}, state: %InternalState{}}
   end
 
   describe "assert" do
-    test "return true if it's integer", %{type: type, opts: opts} do
-      Type.assert(type, 1, opts)
-      Type.assert(type, 0, opts)
-      Type.assert(type, -1, opts)
+    test "return true if it's integer", %{type: type, opts: opts, state: state} do
+      Type.assert(type, 1, opts, state)
+      Type.assert(type, 0, opts, state)
+      Type.assert(type, -1, opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, "1", opts))
-      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts))
+      assert {:error, _} = catch_throw(Type.assert(type, "1", opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts, state))
     end
   end
 end

--- a/test/types/list_test.exs
+++ b/test/types/list_test.exs
@@ -1,20 +1,20 @@
 defmodule ExUnitAssertMatch.Types.ListTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   describe "without example" do
     setup do
-      %{type: %Types.List{}, opts: %Option{}}
+      %{type: %Types.List{}, opts: %Option{}, state: %InternalState{}}
     end
 
-    test "return true if it's list", %{type: type, opts: opts} do
-      Type.assert(type, [], opts)
-      Type.assert(type, [1, 2, 3], opts)
+    test "return true if it's list", %{type: type, opts: opts, state: state} do
+      Type.assert(type, [], opts, state)
+      Type.assert(type, [1, 2, 3], opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, "1", opts))
-      assert {:error, _} = catch_throw(Type.assert(type, :list, opts))
+      assert {:error, _} = catch_throw(Type.assert(type, "1", opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, :list, opts, state))
     end
   end
 
@@ -22,15 +22,15 @@ defmodule ExUnitAssertMatch.Types.ListTest do
     setup do
       type = %Types.List{example: %Types.Binary{}}
 
-      %{type: type, opts: %Option{}}
+      %{type: type, opts: %Option{}, state: %InternalState{}}
     end
 
-    test "fails if the element does not match", %{type: type, opts: opts} do
-      Type.assert(type, [], opts)
-      Type.assert(type, ["a", "b", "c"], opts)
+    test "fails if the element does not match", %{type: type, opts: opts, state: state} do
+      Type.assert(type, [], opts, state)
+      Type.assert(type, ["a", "b", "c"], opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, [1, 2, 3], opts))
+      assert {:error, _} = catch_throw(Type.assert(type, [1, 2, 3], opts, state))
     end
   end
 end

--- a/test/types/literal_test.exs
+++ b/test/types/literal_test.exs
@@ -1,19 +1,19 @@
 defmodule ExUnitAssertMatch.Types.LiteralTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   setup do
-    %{type: %Types.Literal{example: "hello"}, opts: %Option{}}
+    %{type: %Types.Literal{example: "hello"}, opts: %Option{}, state: %InternalState{}}
   end
 
   describe "assert" do
-    test "pass if match with `==`", %{type: type, opts: opts} do
-      Type.assert(type, "hello", opts)
+    test "pass if match with `==`", %{type: type, opts: opts, state: state} do
+      Type.assert(type, "hello", opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, :hello, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, "Hello", opts))
+      assert {:error, _} = catch_throw(Type.assert(type, :hello, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, "Hello", opts, state))
     end
   end
 end

--- a/test/types/map_test.exs
+++ b/test/types/map_test.exs
@@ -1,20 +1,20 @@
 defmodule ExUnitAssertMatch.Types.MapTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   describe "without example" do
     setup do
-      %{type: %Types.Map{}, opts: %Option{}}
+      %{type: %Types.Map{}, opts: %Option{}, state: %InternalState{}}
     end
 
-    test "return true if it's map", %{type: type, opts: opts} do
-      Type.assert(type, %{}, opts)
-      Type.assert(type, %{a: 1}, opts)
+    test "return true if it's map", %{type: type, opts: opts, state: state} do
+      Type.assert(type, %{}, opts, state)
+      Type.assert(type, %{a: 1}, opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, "1", opts))
-      assert {:error, _} = catch_throw(Type.assert(type, :map, opts))
+      assert {:error, _} = catch_throw(Type.assert(type, "1", opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, :map, opts, state))
     end
   end
 
@@ -26,16 +26,16 @@ defmodule ExUnitAssertMatch.Types.MapTest do
         }
       }
 
-      %{type: type, opts: %Option{}}
+      %{type: type, opts: %Option{}, state: %InternalState{}}
     end
 
-    test "fails if the element does not match", %{type: type, opts: opts} do
-      Type.assert(type, %{name: "John"}, opts)
+    test "fails if the element does not match", %{type: type, opts: opts, state: state} do
+      Type.assert(type, %{name: "John"}, opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, %{}, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, %{name: :john}, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, %{age: 28}, opts))
+      assert {:error, _} = catch_throw(Type.assert(type, %{}, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, %{name: :john}, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, %{age: 28}, opts, state))
     end
   end
 end

--- a/test/types/nullable_test.exs
+++ b/test/types/nullable_test.exs
@@ -1,20 +1,20 @@
 defmodule ExUnitAssertMatch.Types.NullableTest do
   use ExUnit.Case, async: true
 
-  alias ExUnitAssertMatch.{Type, Types, Option}
+  alias ExUnitAssertMatch.{Type, Types, Option, InternalState}
 
   setup do
-    %{type: %Types.Nullable{example: %Types.Binary{}}, opts: %Option{}}
+    %{type: %Types.Nullable{example: %Types.Binary{}}, opts: %Option{}, state: %InternalState{}}
   end
 
   describe "assert" do
-    test "pass if it's binary or nil", %{type: type, opts: opts} do
-      Type.assert(type, nil, opts)
-      Type.assert(type, "hello", opts)
+    test "pass if it's binary or nil", %{type: type, opts: opts, state: state} do
+      Type.assert(type, nil, opts, state)
+      Type.assert(type, "hello", opts, state)
 
       opts = %Option{opts | assertion_module: ExUnitAssertMatch.ThrowTupleOnFail}
-      assert {:error, _} = catch_throw(Type.assert(type, 1, opts))
-      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts))
+      assert {:error, _} = catch_throw(Type.assert(type, 1, opts, state))
+      assert {:error, _} = catch_throw(Type.assert(type, 1.0, opts, state))
     end
   end
 end


### PR DESCRIPTION
`ExUnitAssertMatch.Option` has attributes

- `key_stack`
- `assertion_module`

`key_stack` is used internally but `assertion_module` is given by users. So `key_stack` should not be Option. It's state.